### PR TITLE
fix: curriculum page, exhibitions resp layout on mobile

### DIFF
--- a/mac/exposicoes/templates/exposicoes.html
+++ b/mac/exposicoes/templates/exposicoes.html
@@ -6,10 +6,12 @@
    <h2>{% trans "exposições" %}{% block subsection %}{% endblock %}</h2>
 
     {% if exposicoes %}
-    <div class="row row-cols-3 row-cols-md-6 mt-5 artists__card">
-    {% for exhibition in exposicoes %}
-        <div>
-            <div class="card mb-5 border-0 text-center">
+    <div class="container">
+        <div class="row mt-5"> 
+        {% for exhibition in exposicoes %}
+        <div class="col col-sm-2">
+            <div class="card mb-5 text-center shadow">
+                <div class="card-body">
                 <a href="{% url 'exhibition_detail' exhibition.id %}" class="card-link">
                     {% with exhibition.obras.all|first as first_work %}
                         {% if first_work.foto.thumbnail %}
@@ -18,17 +20,21 @@
                             <img src="{% static 'images/photo-placeholder.jpg' %}" class="card-img-top artists__img" alt="image">
                         {% endif %}
                     {% endwith %}
+                </div>
+                <div class="card-text">
                     <div class="mt-3">
                         <p class="text-center artist__text">{{ exhibition.titulo }}</p>
                         <p class="text-center artist__text">{{ exhibition.data_inicio|date:"j M" }} - {{ exhibition.data_fim|date:"j M" }}</p>
                     </div>
+                </div>    
                 </a>
             </div>
         </div>
-        {% endfor %}
-    </div>
+            {% endfor %}
+        </div>
     {% else %}
     <p>{% trans "Não há exposições" %}.</p>
     {% endif %}
+    </div>
 </div>
 {% endblock %}

--- a/mac/galeria/templates/galeria_curriculum.html
+++ b/mac/galeria/templates/galeria_curriculum.html
@@ -17,6 +17,7 @@
                 </div>
             </div>
         </div>
+    </div>
     {% endfor %}
     {% else %}
         <p>Não há curriculum.</p>


### PR DESCRIPTION
        modified:   mac/exposicoes/templates/exposicoes.html
        modified:   mac/galeria/templates/galeria_curriculum.html

fix: 

- on curriculum one missing closing div tag
- on exposicoes: fix layout same as on other pages, responsivity on mobile devices
